### PR TITLE
Dev/import export snapshot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/fxamacker/cbor/v2 v2.2.0
+	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/zllai/go-MerklePatriciaTree v0.0.0-20190826154110-1538c9c6c9e6
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
 github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
@@ -9,6 +12,17 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
@@ -28,3 +42,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mpt/trie_test.go
+++ b/mpt/trie_test.go
@@ -2,8 +2,11 @@ package mpt
 
 import (
 	"bytes"
+	fmt "fmt"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/vldmkr/merkle-patricia-trie/storage"
 )
@@ -483,74 +486,152 @@ func TestPutCommitGetLevelDB(t *testing.T) {
 }
 
 func TestCreateSnapshot(t *testing.T) {
-	// Initialize nodes
-	nodes := []Node{
-		&FullNode{},
-		&ShortNode{Key: []byte("key1"), Value: &ValueNode{Value: []byte("value1")}},
-		&ValueNode{Value: []byte("value2")},
+	store := storage.NewMemoryAdapter()
+	trie := New(nil, store)
+	err := trie.Put([]byte("123456"), []byte("A"))
+	if err != nil {
+		t.Error(err.Error())
 	}
 
-	// Create snapshot
-	snapshot := CreateSnapshot(nodes)
+	err = trie.Put([]byte("134567"), []byte("B"))
+	if err != nil {
+		t.Error(err.Error())
+	}
 
-	// Validate snapshot
-	if len(snapshot) != 3 {
-		t.Errorf("Expected 3 nodes in snapshot, got %d", len(snapshot))
+	snapshot := trie.CreateSnapshot()
+	if len(snapshot) == 0 {
+		t.Error("Snapshot is empty")
+	}
+
+	// Validate snapshot content
+	for key, value := range snapshot {
+		node, err := DeserializeNode(value)
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if string(node.Hash()) != key {
+			t.Errorf("Snapshot key %s does not match node hash %s", key, node.Hash())
+		}
 	}
 }
 
-func TestExportSnapshot(t *testing.T) {
-	// Initialize nodes
-	nodes := []Node{
-		&FullNode{},
-		&ShortNode{Key: []byte("key1"), Value: &ValueNode{Value: []byte("value1")}},
-		&ValueNode{Value: []byte("value2")},
+func TestExportImportSnapshot(t *testing.T) {
+	store := storage.NewMemoryAdapter()
+	trie := New(nil, store)
+
+	// Populate the trie
+	err := trie.Put([]byte("123456"), []byte("A"))
+	if err != nil {
+		t.Fatalf("Failed to put data in trie: %v", err)
+	}
+	err = trie.Put([]byte("134567"), []byte("B"))
+	if err != nil {
+		t.Fatalf("Failed to put data in trie: %v", err)
 	}
 
-	// Export snapshot
-	err := ExportSnapshot("test_snapshot.json", nodes)
+	// Export the snapshot
+	filename := "snapshot_test.json"
+	err = trie.ExportSnapshot(filename)
 	if err != nil {
 		t.Fatalf("Failed to export snapshot: %v", err)
 	}
+	defer os.Remove(filename) // Clean up the file after the test
 
-	// Clean up
-	defer os.Remove("test_snapshot.json")
-}
-
-func TestImportSnapshot(t *testing.T) {
-	// Initialize nodes
-	nodes := []Node{
-		&FullNode{},
-		&ShortNode{Key: []byte("key1"), Value: &ValueNode{Value: []byte("value1")}},
-		&ValueNode{Value: []byte("value2")},
-	}
-
-	// Export snapshot
-	err := ExportSnapshot("test_snapshot.json", nodes)
-	if err != nil {
-		t.Fatalf("Failed to export snapshot: %v", err)
-	}
-	defer os.Remove("test_snapshot.json")
-
-	// Import snapshot
-	importedNodes, err := ImportSnapshot("test_snapshot.json")
+	// Clear the trie and import the snapshot
+	store = storage.NewMemoryAdapter()
+	trie = New(nil, store)
+	err = trie.ImportSnapshot(filename)
 	if err != nil {
 		t.Fatalf("Failed to import snapshot: %v", err)
 	}
 
-	// Validate imported nodes
-	if len(importedNodes) != 3 {
-		t.Errorf("Expected 3 nodes in imported snapshot, got %d", len(importedNodes))
+	// Validate the imported data
+	data, err := trie.Get([]byte("123456"))
+	if err != nil || string(data) != "A" {
+		t.Fatalf("Expected A, got %s (err: %v)", string(data), err)
+	}
+	data, err = trie.Get([]byte("134567"))
+	if err != nil || string(data) != "B" {
+		t.Fatalf("Expected B, got %s (err: %v)", string(data), err)
+	}
+}
+
+func TestValidateSnapshot(t *testing.T) {
+	store := storage.NewMemoryAdapter()
+	trie := New(nil, store)
+	err := trie.Put([]byte("123456"), []byte("A"))
+	if err != nil {
+		t.Error(err.Error())
 	}
 
-	// Additional validation to ensure the nodes are correctly imported
-	for _, node := range nodes {
-		hash := string(node.Hash())
-		importedNode, exists := importedNodes[hash]
-		if !exists {
-			t.Errorf("Node with hash %s not found in imported snapshot", hash)
-		} else if string(importedNode.Hash()) != hash {
-			t.Errorf("Imported node hash mismatch: expected %s, got %s", hash, importedNode.Hash())
-		}
+	err = trie.Put([]byte("134567"), []byte("B"))
+	if err != nil {
+		t.Error(err.Error())
 	}
+
+	snapshot := trie.CreateSnapshot()
+	nodes := make(map[string]Node)
+	for hash, nodeData := range snapshot {
+		node, err := DeserializeNode(nodeData)
+		if err != nil {
+			t.Error(err.Error())
+		}
+		nodes[hash] = node
+	}
+
+	if !ValidateSnapshot(nodes) {
+		t.Error("Snapshot validation failed")
+	}
+}
+
+func TestPruneOldSnapshots(t *testing.T) {
+    // Create a temporary directory for snapshots
+    dir, err := os.MkdirTemp("", "snapshots")
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer os.RemoveAll(dir) // Clean up the directory after the test
+
+    // Create dummy snapshot files
+    for i := 0; i < 5; i++ {
+        file, err := os.Create(filepath.Join(dir, fmt.Sprintf("snapshot_%d.json", i)))
+        if err != nil {
+            t.Fatal(err)
+        }
+        file.Close()
+        time.Sleep(1 * time.Second) // Ensure different modification times
+    }
+
+    // List files before pruning
+	files, err := os.ReadDir(dir)
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("Files before pruning: %v", getFilenames(files))
+
+    // Prune snapshots to keep only 3
+    err = PruneOldSnapshots(dir, 3)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    // List files after pruning
+    files, err = os.ReadDir(dir)
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("Files after pruning: %v", getFilenames(files))
+
+    if len(files) != 3 {
+        t.Fatalf("Expected 3 snapshots, got %d", len(files))
+    }
+}
+
+// Helper function to get filenames from os.DirEntry slice
+func getFilenames(files []os.DirEntry) []string {
+    var filenames []string
+    for _, file := range files {
+        filenames = append(filenames, file.Name())
+    }
+    return filenames
 }

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -57,7 +57,7 @@ func (kv *MemoryAdapter) Delete(key []byte) error {
 	if _, ok := kv.store[keyHex]; ok {
 		delete(kv.store, keyHex)
 	} else {
-		return errors.New(fmt.Sprintf("[MemKV] key not found: %s", keyHex))
+		return fmt.Errorf("[MemKV] key not found: %s", keyHex)
 	}
 	return nil
 }

--- a/storage/memory_adapter_test.go
+++ b/storage/memory_adapter_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"log"
 	"os"
 	"testing"
 )
@@ -54,6 +55,8 @@ func TestMemoryAdapter(t *testing.T) {
 }
 
 func TestBatchPut(t *testing.T) {
+	log.Println("TestBatchPut: Starting test")
+
 	// Initialize the MemoryAdapter
 	kv := NewMemoryAdapter()
 
@@ -62,18 +65,42 @@ func TestBatchPut(t *testing.T) {
 		{[]byte("key1"), []byte("value1")},
 		{[]byte("key2"), []byte("value2")},
 	}
+	log.Println("TestBatchPut: Calling BatchPut")
 	err := kv.BatchPut(kvs)
 	if err != nil {
 		t.Fatalf("Failed to batch put data: %v", err)
 	}
+	log.Println("TestBatchPut: BatchPut completed")
 
 	// Validate the data
 	value, err := kv.Get([]byte("key1"))
 	if err != nil || string(value) != "value1" {
 		t.Fatalf("Expected value1, got %s (err: %v)", string(value), err)
 	}
+	log.Println("TestBatchPut: Validated key1")
+
 	value, err = kv.Get([]byte("key2"))
 	if err != nil || string(value) != "value2" {
 		t.Fatalf("Expected value2, got %s (err: %v)", string(value), err)
+	}
+	log.Println("TestBatchPut: Validated key2")
+
+	log.Println("TestBatchPut: Test completed successfully")
+}
+
+func TestGet(t *testing.T) {
+	// Initialize the MemoryAdapter
+	kv := NewMemoryAdapter()
+
+	// Add some data to the MemoryAdapter
+	err := kv.Put([]byte("key1"), []byte("value1"))
+	if err != nil {
+		t.Fatalf("Failed to put data: %v", err)
+	}
+
+	// Get the value
+	value, err := kv.Get([]byte("key1"))
+	if err != nil || string(value) != "value1" {
+		t.Fatalf("Expected value1, got %s (err: %v)", string(value), err)
 	}
 }

--- a/storage/memory_adapter_test.go
+++ b/storage/memory_adapter_test.go
@@ -1,0 +1,79 @@
+package storage
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMemoryAdapter(t *testing.T) {
+	// Initialize the MemoryAdapter
+	kv := NewMemoryAdapter()
+
+	// Add some data to the MemoryAdapter
+	err := kv.Put([]byte("key1"), []byte("value1"))
+	if err != nil {
+		t.Fatalf("Failed to put data: %v", err)
+	}
+	err = kv.Put([]byte("key2"), []byte("value2"))
+	if err != nil {
+		t.Fatalf("Failed to put data: %v", err)
+	}
+
+	// Create a snapshot
+	snapshot := kv.CreateSnapshot()
+	if len(snapshot) != 2 {
+		t.Fatalf("Expected snapshot length 2, got %d", len(snapshot))
+	}
+
+	// Export the snapshot to a file
+	filename := "snapshot_test.json"
+	err = kv.ExportSnapshot(filename)
+	if err != nil {
+		t.Fatalf("Failed to export snapshot: %v", err)
+	}
+	defer os.Remove(filename) // Clean up the file after the test
+
+	// Clear the MemoryAdapter
+	kv.store = make(map[string][]byte)
+
+	// Import the snapshot from the file
+	err = kv.ImportSnapshot(filename)
+	if err != nil {
+		t.Fatalf("Failed to import snapshot: %v", err)
+	}
+
+	// Validate the imported data
+	value, err := kv.Get([]byte("key1"))
+	if err != nil || string(value) != "value1" {
+		t.Fatalf("Expected value1, got %s (err: %v)", string(value), err)
+	}
+	value, err = kv.Get([]byte("key2"))
+	if err != nil || string(value) != "value2" {
+		t.Fatalf("Expected value2, got %s (err: %v)", string(value), err)
+	}
+}
+
+func TestBatchPut(t *testing.T) {
+	// Initialize the MemoryAdapter
+	kv := NewMemoryAdapter()
+
+	// Add multiple key-value pairs using BatchPut
+	kvs := [][2][]byte{
+		{[]byte("key1"), []byte("value1")},
+		{[]byte("key2"), []byte("value2")},
+	}
+	err := kv.BatchPut(kvs)
+	if err != nil {
+		t.Fatalf("Failed to batch put data: %v", err)
+	}
+
+	// Validate the data
+	value, err := kv.Get([]byte("key1"))
+	if err != nil || string(value) != "value1" {
+		t.Fatalf("Expected value1, got %s (err: %v)", string(value), err)
+	}
+	value, err = kv.Get([]byte("key2"))
+	if err != nil || string(value) != "value2" {
+		t.Fatalf("Expected value2, got %s (err: %v)", string(value), err)
+	}
+}


### PR DESCRIPTION
Added import and export functionality for the trie.

Now new snapshot files can be created based on the trie, which will export all the data into json file after serializing and the import will get the json file and update the trie node